### PR TITLE
Add Github action that runs the tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,19 @@
+name: Limitador-Operator
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+      - name: Run the tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# The "source" command used in the "test" target does not work with /bin/sh.
+SHELL := /bin/bash
+
 # Current Operator version
 VERSION ?= 0.0.1
 # Default bundle image tag


### PR DESCRIPTION
For now it just runs "make test". After fixing the build of the docker image we could add other targets to make sure that the image can be built and deployed to kubernetes.