### PR TITLE
controllers/limitador: use owner refs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ ENVTEST_ASSETS_DIR = $(shell pwd)/testbin
 test: generate fmt vet manifests
 	mkdir -p $(ENVTEST_ASSETS_DIR)
 	test -f $(ENVTEST_ASSETS_DIR)/setup-envtest.sh || curl -sSLo $(ENVTEST_ASSETS_DIR)/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.6.3/hack/setup-envtest.sh
-	source $(ENVTEST_ASSETS_DIR)/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
+	source $(ENVTEST_ASSETS_DIR)/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out -v
 
 # Build manager binary
 manager: generate fmt vet

--- a/controllers/limitador_controller.go
+++ b/controllers/limitador_controller.go
@@ -22,9 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -50,16 +48,8 @@ func (r *LimitadorReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	limitadorObj := limitadorv1alpha1.Limitador{}
 	if err := r.Get(context.TODO(), req.NamespacedName, &limitadorObj); err != nil {
 		if errors.IsNotFound(err) {
-			if err = r.ensureLimitadorDeploymentIsDeleted(req.NamespacedName); err != nil {
-				reqLogger.Error(err, "Failed to delete Limitador deployment.")
-				return ctrl.Result{}, err
-			}
-
-			if err = r.ensureLimitadorServiceIsDeleted(); err != nil {
-				reqLogger.Error(err, "Failed to delete Limitador service.")
-				return ctrl.Result{}, err
-			}
-
+			// The deployment and the service should be deleted automatically
+			// because they have an owner ref to Limitador
 			return ctrl.Result{}, nil
 		} else {
 			reqLogger.Error(err, "Failed to get Limitador object.")
@@ -67,7 +57,11 @@ func (r *LimitadorReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		}
 	}
 
-	if err := r.ensureLimitadorServiceExists(); err != nil {
+	if limitadorObj.GetDeletionTimestamp() != nil { // Marked to be deleted
+		return ctrl.Result{}, nil
+	}
+
+	if err := r.ensureLimitadorServiceExists(&limitadorObj); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -121,25 +115,8 @@ func (r *LimitadorReconciler) reconcileDeployment(desiredDeployment *v1.Deployme
 	}
 }
 
-func (r *LimitadorReconciler) ensureLimitadorDeploymentIsDeleted(name types.NamespacedName) error {
-	currentLimitadorDeployment := v1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name.Name,
-			Namespace: name.Namespace,
-		},
-	}
-
-	err := r.Delete(context.TODO(), &currentLimitadorDeployment)
-
-	if err != nil && !errors.IsNotFound(err) {
-		return err
-	}
-
-	return nil
-}
-
-func (r *LimitadorReconciler) ensureLimitadorServiceExists() error {
-	limitadorService := limitador.LimitadorService()
+func (r *LimitadorReconciler) ensureLimitadorServiceExists(limitadorObj *limitadorv1alpha1.Limitador) error {
+	limitadorService := limitador.LimitadorService(limitadorObj)
 	limitadorServiceKey, _ := client.ObjectKeyFromObject(limitadorService)
 
 	err := r.Get(context.TODO(), limitadorServiceKey, limitadorService)
@@ -149,16 +126,6 @@ func (r *LimitadorReconciler) ensureLimitadorServiceExists() error {
 		} else {
 			return err
 		}
-	}
-
-	return nil
-}
-
-func (r *LimitadorReconciler) ensureLimitadorServiceIsDeleted() error {
-	err := r.Delete(context.TODO(), limitador.LimitadorService())
-
-	if err != nil && !errors.IsNotFound(err) {
-		return err
 	}
 
 	return nil

--- a/pkg/limitador/k8s_objects.go
+++ b/pkg/limitador/k8s_objects.go
@@ -9,26 +9,26 @@ import (
 )
 
 const (
-	DefaultVersion   = "latest"
-	DefaultReplicas  = 1
-	ServiceName      = "limitador"
-	ServiceNamespace = "default"
-	Image            = "quay.io/3scale/limitador"
-	StatusEndpoint   = "/status"
-	ServiceHTTPPort  = 8080
-	ServiceGRPCPort  = 8081
+	DefaultVersion  = "latest"
+	DefaultReplicas = 1
+	ServiceName     = "limitador"
+	Image           = "quay.io/3scale/limitador"
+	StatusEndpoint  = "/status"
+	ServiceHTTPPort = 8080
+	ServiceGRPCPort = 8081
 )
 
-func LimitadorService() *v1.Service {
+func LimitadorService(limitador *limitadorv1alpha1.Limitador) *v1.Service {
 	return &v1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ServiceName,
-			Namespace: ServiceNamespace,
-			Labels:    labels(),
+			Name:            ServiceName,
+			Namespace:       limitador.ObjectMeta.Namespace, // TODO: revisit later. For now assume same.
+			Labels:          labels(),
+			OwnerReferences: []metav1.OwnerReference{ownerRefToLimitador(limitador)},
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
@@ -69,9 +69,10 @@ func LimitadorDeployment(limitador *limitadorv1alpha1.Limitador) *appsv1.Deploym
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      limitador.ObjectMeta.Name,      // TODO: revisit later. For now assume same.
-			Namespace: limitador.ObjectMeta.Namespace, // TODO: revisit later. For now assume same.
-			Labels:    labels(),
+			Name:            limitador.ObjectMeta.Name,      // TODO: revisit later. For now assume same.
+			Namespace:       limitador.ObjectMeta.Namespace, // TODO: revisit later. For now assume same.
+			Labels:          labels(),
+			OwnerReferences: []metav1.OwnerReference{ownerRefToLimitador(limitador)},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
@@ -144,4 +145,13 @@ func LimitadorDeployment(limitador *limitadorv1alpha1.Limitador) *appsv1.Deploym
 
 func labels() map[string]string {
 	return map[string]string{"app": "limitador"}
+}
+
+func ownerRefToLimitador(limitador *limitadorv1alpha1.Limitador) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: limitador.APIVersion,
+		Kind:       limitador.Kind,
+		Name:       limitador.Name,
+		UID:        limitador.UID,
+	}
 }


### PR DESCRIPTION
So the deployment and the service are deleted automatically when a
Limitador object is deleted.

* Fix limitador service namespace, which was harcoded to `default`
* Fix tests: Removing `Deleting a Limitador object` because the test context does not support garbage collection [link](https://book.kubebuilder.io/reference/envtest.html#testing-considerations)